### PR TITLE
Fix GRASS plugin failures

### DIFF
--- a/src/main/java/applicationContext.xml
+++ b/src/main/java/applicationContext.xml
@@ -7,7 +7,4 @@
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
 
 <beans>
-
-	<bean id="helloWorld" class="HelloWorld"/>	
-
 </beans>

--- a/src/main/java/com/boundlessgeo/wps/grass/GrassProcesses.java
+++ b/src/main/java/com/boundlessgeo/wps/grass/GrassProcesses.java
@@ -187,9 +187,10 @@ public class GrassProcesses extends StaticMethodsProcessFactory<GrassProcesses> 
 			double y) throws Exception{
 		
 		String COMMAND = "viewshed";
-		File geodb = new File(System.getProperty("user.home"),"grassdata");		
+		//Stage files in a temporary location
+		File geodb = Files.createTempDirectory("grassdata").toFile();
+		geodb.deleteOnExit();
 		File location = new File( geodb, COMMAND + Long.toString(random.nextLong()) + "location");
-		//File location = new File( geodb, COMMAND );
 		
 		// stage dem file
 		File file = new File( geodb, "dem.tif");		

--- a/src/main/java/com/boundlessgeo/wps/grass/GrassProcesses.java
+++ b/src/main/java/com/boundlessgeo/wps/grass/GrassProcesses.java
@@ -156,6 +156,11 @@ public class GrassProcesses extends StaticMethodsProcessFactory<GrassProcesses> 
 		
 		// stage dem file
 		File file = new File( geodb, "dem.tif");		
+		//The file must exist for FileImageOutputStreamExtImplSpi to create the output stream
+		if (!file.exists()) {
+		    file.getParentFile().mkdirs();
+		    file.createNewFile();
+		}
 		final GeoTiffFormat format = new GeoTiffFormat();
 		GridCoverageWriter writer = format.getWriter(file);
 		writer.write(dem, null);


### PR DESCRIPTION
Fixed a failure in the viewshed process:
When creating the gridCoverageWriter, the format.getWriter(file) calls FileImageOutputStreamExtImplSpi.createOutputStreamInstance(file), which requires the file to exist on the filesystem, otherwise it returns null and logs an error at the FINE level.
This null stream is then passed into GeoTiff writer, which throws an exception:

```
java.lang.NullPointerException: Some input parameters are null
    at org.geotools.gce.geotiff.GeoTiffWriter.writeImage(GeoTiffWriter.java:403)
    at org.geotools.gce.geotiff.GeoTiffWriter.write(GeoTiffWriter.java:272)
    at com.boundlessgeo.wps.grass.GrassProcesses.viewshed(GrassProcesses.java:164)
    ...

```
